### PR TITLE
Fix Photon-Beetle-AEAD-128

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,10 @@ python3 -m pip install -r wrapper/python/requirements.txt --user
 
 ## Testing
 
-For checking functional correctness of Photon-Beetle implementation, I use test vectors submitted with NIST LWC submission package. 
+For checking functional correctness & conformance with standard of Photon-Beetle implementation, I use test vectors submitted with NIST LWC submission package.
 
 - For testing Photon-Beetle-Hash, I use same input bytes as provided in Known Answer Tests ( KATs ) & match computed digest(s) against provided ones.
-- While for Photon-Beetle-AEAD, I'm using given secret key, nonce, associated data & plain text ( in KATs ) and computing cipher text, authentication tag. After that I also attempt to decrypt cipher text back to plain text while checking for truth value in verification flag.
-
-> Consider taking a look at https://github.com/itzmeanjan/photon-beetle/commit/9d629e3 to understand why I've disable some assertions for Photon-Beetle-AEAD[128] implementation
+- While for Photon-Beetle-AEAD, I'm using given secret key, nonce, associated data & plain text ( in KATs ) and computing cipher text, authentication tag. After that I also attempt to decrypt cipher text back to plain text while checking for truth value in verification flag. Finally to ensure conformance, I make sure to check both computed cipher text and authentication tag with given ones in test vectors.
 
 For executing tests, issue
 
@@ -81,6 +79,8 @@ make
 ## Benchmarking
 
 For benchmarking Photon-Beetle-{Hash, AEAD} on CPU based systems, issue
+
+> If your CPU has scaling enabled, you may want to disable that, see [this](https://github.com/google/benchmark/blob/60b16f1/docs/user_guide.md#disabling-cpu-frequency-scaling) guide.
 
 ```fish
 make benchmark

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -34,6 +34,12 @@ encrypt(
 
   uint8_t state[64] = {};
 
+#if defined __clang__
+#pragma unroll 16
+#elif defined __GNUG__
+#pragma GCC unroll 16
+#pragma GCC ivdep
+#endif
   for (size_t i = 0; i < 16; i++) {
     const size_t off0 = i << 1;
     const size_t off1 = 32ul ^ off0;
@@ -113,6 +119,12 @@ decrypt(
   uint8_t state[64] = {};
   uint8_t tag_[16] = {};
 
+#if defined __clang__
+#pragma unroll 16
+#elif defined __GNUG__
+#pragma GCC unroll 16
+#pragma GCC ivdep
+#endif
   for (size_t i = 0; i < 16; i++) {
     const size_t off0 = i << 1;
     const size_t off1 = 32ul ^ off0;

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -122,22 +122,19 @@ shuffle(const uint8_t* const __restrict state,
         uint8_t* const __restrict shuffled) requires(check_po2(RATE))
 {
   if constexpr (RATE == 4ul) {
-    const uint16_t s1 = (static_cast<uint16_t>(state[1] & photon::LS4B) << 12) |
-                        (static_cast<uint16_t>(state[0] & photon::LS4B) << 8) |
-                        (static_cast<uint16_t>(state[3] & photon::LS4B) << 4) |
-                        (static_cast<uint16_t>(state[2] & photon::LS4B) << 0);
+    const uint16_t s1 = (static_cast<uint16_t>(state[3] & photon::LS4B) << 12) |
+                        (static_cast<uint16_t>(state[2] & photon::LS4B) << 8) |
+                        (static_cast<uint16_t>(state[1] & photon::LS4B) << 4) |
+                        (static_cast<uint16_t>(state[0] & photon::LS4B) << 0);
 
     const uint16_t s1_prime = std::rotr(s1, 1);
 
-    shuffled[0] = state[4];
-    shuffled[1] = state[5];
-    shuffled[2] = state[6];
-    shuffled[3] = state[7];
+    std::memcpy(shuffled, state + RATE, RATE);
 
-    shuffled[4] = static_cast<uint8_t>(s1_prime >> 8) & photon::LS4B;
-    shuffled[5] = static_cast<uint8_t>(s1_prime >> 12) & photon::LS4B;
-    shuffled[6] = static_cast<uint8_t>(s1_prime >> 0) & photon::LS4B;
-    shuffled[7] = static_cast<uint8_t>(s1_prime >> 4) & photon::LS4B;
+    shuffled[4] = static_cast<uint8_t>(s1_prime >> 0) & photon::LS4B;
+    shuffled[5] = static_cast<uint8_t>(s1_prime >> 4) & photon::LS4B;
+    shuffled[6] = static_cast<uint8_t>(s1_prime >> 8) & photon::LS4B;
+    shuffled[7] = static_cast<uint8_t>(s1_prime >> 12) & photon::LS4B;
   } else if constexpr (RATE == 16ul) {
     constexpr size_t CNT = RATE >> 1;
 
@@ -145,7 +142,7 @@ shuffle(const uint8_t* const __restrict state,
 
     for (size_t i = 0; i < CNT; i++) {
       const size_t soff = i << 1;
-      const size_t shift = (7 - i) << 3;
+      const size_t shift = i << 3;
 
       const uint8_t w = (state[soff ^ 1] << 4) | (state[soff] & photon::LS4B);
 
@@ -154,14 +151,7 @@ shuffle(const uint8_t* const __restrict state,
 
     const uint64_t s1_prime = std::rotr(s1, 1);
 
-#if defined __clang__
-#pragma unroll 16
-#elif defined __GNUG__
-#pragma GCC unroll 16
-#endif
-    for (size_t i = 0; i < RATE; i++) {
-      shuffled[i] = state[RATE ^ i];
-    }
+    std::memcpy(shuffled, state + RATE, RATE);
 
 #if defined __clang__
 #pragma unroll 8
@@ -170,7 +160,7 @@ shuffle(const uint8_t* const __restrict state,
 #endif
     for (size_t i = 0; i < CNT; i++) {
       const size_t soff = RATE ^ (i << 1);
-      const size_t shift = (7 - i) << 3;
+      const size_t shift = i << 3;
 
       const uint8_t w = static_cast<uint8_t>(s1_prime >> shift);
 

--- a/wrapper/python/test_photon_beetle.py
+++ b/wrapper/python/test_photon_beetle.py
@@ -163,25 +163,7 @@ def test_photon_beetle_aead_128_kat():
             cipher, tag = pb.photon_beetle_128_encrypt(key, nonce, ad, pt)
             flag, text = pb.photon_beetle_128_decrypt(key, nonce, tag, ad, cipher)
             
-            # @note
-            # Following assertion should ideally be enabled, though it's not at this moment because I discovered
-            # there's a mismatch in high nibble of last byte of computed cipher text & expected cipher text of some
-            # of Photon-Beetle-AEAD[128] KATs.
-            # 
-            # For example, in case of KAT 298 ( see file LWC_AEAD_KAT_128_128.txt in submission package ), 
-            # expected cipher text is 0xa7b9af5ba1aa580976, though computed one is 0xa7b9af5ba1aa5809f6.
-            # Notice the difference in 4 most significant bits of last byte.
-            #
-            # Similarly for KAT 299 ( of same file ), notice expected cipher text is 0x856bb76c8303baed04, though this implementation computed one is
-            # 0x856bb76c8303baed84. Difference is only in the most significant 4 bits of last byte. If you carefully notice the difference
-            # it's actually of 0x80 in last byte, for both cases.
-            #
-            # Note, this doesn't change computed authentication tag and with my implementation computed cipher text I can 
-            # decrypt back original bytes. As I've not yet figured it out, I'm disabling this test, in a future day
-            # when I'm able to resolve it, I'll reenable it. In the meantime, any help in deciphering it, will be appreciated.
-            #
-            # assert cipher == ct[:len(pt)], f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected cipher to be 0x{ct[:len(pt)].hex()}, found 0x{cipher.hex()} !"
-            assert tag == ct[len(pt):], f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected tag to be 0x{ct[len(pt):].hex()}, found 0x{tag.hex()} !"
+            assert (cipher + tag == ct), f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
             assert (pt == text and flag), f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
 
             # don't need this line, so discard


### PR DESCRIPTION
An issue I described in commit https://github.com/itzmeanjan/photon-beetle/commit/9d629e3 has now been fixed in commit https://github.com/itzmeanjan/photon-beetle/commit/e336511b2f5c26fa6d431443e4969b3f23078ef3. 

Rotating first 64 -bits of RATE portion of permutation state ( note, RATE = 128 -bit for Photon-Beetle-AEAD-128 ) requires me to construct one 64 -bit word, which should have been assemled by placing first 8 -bytes of permutation state in little endian order. Previously it was done using big endian byte ordering, which resulted into generation of mismatching cipher text bytes, for test vectors. 