### PR TITLE
Refactoring Photon256 and Photon-Beetle Testing

### DIFF
--- a/.github/workflows/test_kat.yml
+++ b/.github/workflows/test_kat.yml
@@ -9,15 +9,22 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup compiler
+    - name: Setup C++ compiler
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-    - name: Install Python dependencies
-      run: python3 -m pip install -r wrapper/python/requirements.txt --user
+    - name: Setup Python workspace
+      run: |
+        python -m venv wrapper/python
+        source wrapper/python/bin/activate
+        python -m pip install -r wrapper/python/requirements.txt
     - name: Execute tests
       run: make
+    - name: Clean up
+      run: |
+        deactivate
+        make clean

--- a/.github/workflows/test_kat.yml
+++ b/.github/workflows/test_kat.yml
@@ -17,14 +17,12 @@ jobs:
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-    - name: Setup Python workspace
+    - name: Run tests
       run: |
         python -m venv wrapper/python
         source wrapper/python/bin/activate
         python -m pip install -r wrapper/python/requirements.txt
-    - name: Execute tests
-      run: make
-    - name: Clean up
-      run: |
+        make
         deactivate
-        make clean
+    - name: Clean up
+      run: make clean

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ __pycache__
 # For Clangd
 compile_commands.json
 .cache
+
+wrapper/python/bin
+wrapper/python/lib
+wrapper/python/lib64
+wrapper/python/pyvenv.cfg

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ clean:
 
 format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
+	python3 -m black wrapper/python/*.py
 
 test_kat:
 	bash test_kat.sh

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -21,7 +21,7 @@ constexpr size_t TAG_LEN = 16ul;
 // tag ( computed during decryption ), this routine performs a byte-wise match
 // between those two byte arrays and returns boolean truth value if they match.
 // Otherwise it returns false.
-inline static bool
+inline bool
 verify_tag(const uint8_t* const __restrict expected, // 16 -bytes
            const uint8_t* const __restrict computed  // 16 -bytes
 )

--- a/include/bench/bench_aead.hpp
+++ b/include/bench/bench_aead.hpp
@@ -34,10 +34,8 @@ aead_encrypt(benchmark::State& state)
     benchmark::DoNotOptimize(key);
     benchmark::DoNotOptimize(nonce);
     benchmark::DoNotOptimize(data);
-    benchmark::DoNotOptimize(dlen);
     benchmark::DoNotOptimize(txt);
     benchmark::DoNotOptimize(enc);
-    benchmark::DoNotOptimize(mlen);
     benchmark::DoNotOptimize(tag);
     benchmark::ClobberMemory();
   }
@@ -101,10 +99,8 @@ aead_decrypt(benchmark::State& state)
     benchmark::DoNotOptimize(nonce);
     benchmark::DoNotOptimize(tag);
     benchmark::DoNotOptimize(data);
-    benchmark::DoNotOptimize(dlen);
     benchmark::DoNotOptimize(enc);
     benchmark::DoNotOptimize(dec);
-    benchmark::DoNotOptimize(mlen);
     benchmark::ClobberMemory();
   }
 

--- a/include/bench/bench_hash.hpp
+++ b/include/bench/bench_hash.hpp
@@ -8,7 +8,7 @@ namespace bench_photon_beetle {
 // Benchmarks Photon-Beetle cryptographic hash function implementation for
 // random input of length N (>=0) -bytes | N is provided when setting up
 // benchmark
-void
+inline void
 hash(benchmark::State& state)
 {
   const size_t mlen = static_cast<size_t>(state.range(0));
@@ -22,7 +22,6 @@ hash(benchmark::State& state)
     photon_beetle::hash(msg, mlen, out);
 
     benchmark::DoNotOptimize(msg);
-    benchmark::DoNotOptimize(mlen);
     benchmark::DoNotOptimize(out);
     benchmark::ClobberMemory();
   }

--- a/include/bench/bench_photon.hpp
+++ b/include/bench/bench_photon.hpp
@@ -6,7 +6,7 @@
 namespace bench_photon_beetle {
 
 // Benchmarks Photon256 permutation routine
-void
+inline void
 permute(benchmark::State& state)
 {
   uint8_t pstate[32];

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -9,14 +9,14 @@ static_assert(__SIZEOF_INT128__ == 16, "128 -bit unsigned integer is needed !");
 using uint128_t = unsigned __int128;
 
 // Compile-time check for ensuring that RATE ∈ {4, 16}
-inline static consteval bool
+consteval bool
 check_rate(const size_t rate)
 {
   return (rate == 4) || (rate == 16);
 }
 
 // Compile-time check for ensuring that OUT ∈ {16, 32}
-inline static consteval bool
+consteval bool
 check_out(const size_t out)
 {
   return (out == 16) || (out == 32);

--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -17,7 +17,7 @@ constexpr size_t DIGEST_LEN = 32ul;
 // See `PHOTON-Beetle-Hash[r](M)` algorithm defined in figure 3.6 of
 // Photon-Beetle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/photon-beetle-spec-final.pdf
-inline static void
+inline void
 hash(const uint8_t* const __restrict msg, // input message
      const size_t mlen,                   // len(msg) >= 0
      uint8_t* const __restrict digest     // 32 -bytes digest

--- a/include/photon.hpp
+++ b/include/photon.hpp
@@ -363,7 +363,7 @@ mix_column_serial(uint8_t* const __restrict state)
 
 // Photon256 permutation composed of 12 rounds, applied on a state matrix of
 // dimension 8x4, see chapter 2 ( on page 2 ) of the specification
-inline static void
+inline void
 photon256(uint8_t* const __restrict state)
 {
   for (size_t i = 0; i < ROUNDS; i++) {

--- a/include/photon.hpp
+++ b/include/photon.hpp
@@ -2,6 +2,7 @@
 #include "utils.hpp"
 #include <array>
 #include <bit>
+#include <cstdint>
 #include <cstring>
 
 #if defined __SSSE3__
@@ -41,15 +42,6 @@ constexpr std::array<uint32_t, 96> RC{
   11, 10, 8,  12, 4,  5,  7,  3,  6,  7,  5, 1,  9,  8,  10, 14, 12, 13, 15, 11,
   3,  2,  0,  4,  9,  8,  10, 14, 6,  7,  5, 1,  2,  3,  1,  5,  13, 12, 14, 10,
   5,  4,  6,  2,  10, 11, 9,  13, 10, 11, 9, 13, 5,  4,  6,  2
-};
-
-// M^8 = Serial[2, 4, 2, 11, 2, 8, 5, 6] ^ 8 | Serial[...] is defined in
-// section 1.1 of the specification
-constexpr std::array<uint8_t, 64> M8{
-  2,  4,  2,  11, 2,  8, 5,  6,  12, 9,  8,  13, 7,  7,  5,  2,
-  4,  4,  13, 13, 9,  4, 13, 9,  1,  6,  5,  1,  12, 13, 15, 14,
-  15, 12, 9,  13, 14, 5, 14, 13, 9,  14, 5,  15, 4,  12, 9,  6,
-  12, 2,  2,  10, 3,  1, 1,  14, 15, 1,  13, 10, 5,  10, 2,  3
 };
 
 // Compile-time compute 8 -bit S-box table from 4 -bit S-box table
@@ -117,6 +109,68 @@ constexpr std::array<uint8_t, 256> SBOX = compute_8bit_sbox();
 // multiply a with b s.t. a, b ∈ GF(2^4), look up what's the value stored at
 // index (a*16 + b) of this array.
 constexpr std::array<uint8_t, 256> GF16_MUL_TAB = compute_gf16_mul_table();
+
+// Given a 8x8 matrix M s.t. its elements ∈ GF(2^4), this compile time
+// executable routine is used for squaring M i.e. returning M' <- M x M s.t. M'
+// is a 8x8 matrix over GF(2^4), meaning the matrix multiplication is performed
+// over GF(2^4), using pre-computed multiplication lookup table.
+constexpr std::array<uint8_t, 64>
+gf16_matrix_square(std::array<uint8_t, 64> mat)
+{
+  std::array<uint8_t, 64> res{};
+
+#if defined __clang__
+#pragma clang loop unroll(enable)
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < 8; i++) {
+
+#if defined __clang__
+#pragma clang loop unroll(enable)
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 8
+#endif
+    for (size_t k = 0; k < 8; k++) {
+#if defined __clang__
+#pragma clang loop unroll(enable)
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 8
+#endif
+      for (size_t j = 0; j < 8; j++) {
+        const uint8_t idx = (mat[i * 8 + k] << 4) | (mat[(k * 8) + j] & LS4B);
+        res[i * 8 + j] ^= GF16_MUL_TAB[idx];
+      }
+    }
+  }
+
+  return res;
+}
+
+// Given a serial matrix M <- Serial[2, 4, 2, 11, 2, 8, 5, 6] as it's defined in
+// section 1.1 of the specification, this compile-time executable routine is
+// used for raising M to its 8th power, by repeated squaring, returning M^8.
+constexpr std::array<uint8_t, 64>
+compute_M8()
+{
+  std::array<uint8_t, 64> M{ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,  0, 0, 0, 0,
+                             0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,  1, 0, 0, 0,
+                             0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,  0, 0, 1, 0,
+                             0, 0, 0, 0, 0, 0, 0, 1, 2, 4, 2, 11, 2, 8, 5, 6 };
+
+  auto M2 = gf16_matrix_square(M);
+  auto M4 = gf16_matrix_square(M2);
+  auto M8 = gf16_matrix_square(M4);
+
+  return M8;
+}
+
+// Compile-time computed M^8 = Serial[2, 4, 2, 11, 2, 8, 5, 6] ^ 8 | Serial[...]
+// is defined in section 1.1 of the specification.
+constexpr std::array<uint8_t, 64> M8 = compute_M8();
 
 // Add fixed constants to the cells of first column of 8x4 permutation state,
 // see figure 2.1 of the specification

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -13,7 +13,7 @@ namespace photon_utils {
 //
 // Taken from
 // https://github.com/itzmeanjan/xoodyak/blob/89b3427/include/utils.hpp#L14-L28
-static inline constexpr uint32_t
+inline constexpr uint32_t
 bswap32(const uint32_t a)
 {
 #if defined __GNUG__
@@ -26,7 +26,7 @@ bswap32(const uint32_t a)
 
 // Given a bytearray of length N, this function converts it to human readable
 // hex string of length N << 1 | N >= 0
-static inline const std::string
+inline const std::string
 to_hex(const uint8_t* const bytes, const size_t len)
 {
   std::stringstream ss;
@@ -40,7 +40,7 @@ to_hex(const uint8_t* const bytes, const size_t len)
 }
 
 // Generates N -many random bytes | N >= 0
-static inline void
+inline void
 random_data(uint8_t* const data, const size_t len)
 {
   std::random_device rd;

--- a/test_kat.sh
+++ b/test_kat.sh
@@ -5,29 +5,23 @@
 # generate shared library object
 make lib
 
-# ---
-
 mkdir -p tmp
 pushd tmp
 
 # download compressed NIST LWC submission of Photon-Beetle
 wget -O photon-beetle.zip https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-submissions/photon-beetle.zip
-# uncomress
+# decompress
 unzip photon-beetle.zip
 
-# copy Known Answer Tests outside of uncompressed NIST LWC submission directory
+# copy Known Answer Tests outside of decompressed NIST LWC submission directory
 cp photon-beetle/Implementations/crypto_hash/photonbeetlehash256rate32v1/LWC_HASH_KAT_256.txt ../
 cp photon-beetle/Implementations/crypto_aead/photonbeetleaead128rate32v1/LWC_AEAD_KAT_128_128.txt ../LWC_AEAD_KAT_128_128.txt.32
 cp photon-beetle/Implementations/crypto_aead/photonbeetleaead128rate128v1/LWC_AEAD_KAT_128_128.txt ../LWC_AEAD_KAT_128_128.txt.128
 
 popd
 
-# ---
-
 # remove NIST LWC submission zip
 rm -rf tmp
-
-# ---
 
 pushd wrapper/python
 
@@ -47,5 +41,3 @@ rm LWC_*_KAT_*.txt
 popd
 
 make clean
-
-# ---

--- a/wrapper/python/requirements.txt
+++ b/wrapper/python/requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.22.4
-pytest==7.1.2
+pytest==7.3.1
+black==23.3.0

--- a/wrapper/python/test_photon_beetle.py
+++ b/wrapper/python/test_photon_beetle.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 
 import photon_beetle as pb
-import numpy as np
-
-u8 = np.uint8
 
 
 def test_photon_beetle_hash_kat():
@@ -27,19 +24,25 @@ def test_photon_beetle_hash_kat():
             msg = [i.strip() for i in msg.split("=")][-1]
             md = [i.strip() for i in md.split("=")][-1]
 
-            msg = bytes([
-                int(f"0x{msg[(i << 1): ((i+1) << 1)]}", base=16)
-                for i in range(len(msg) >> 1)
-            ])
+            msg = bytes(
+                [
+                    int(f"0x{msg[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(msg) >> 1)
+                ]
+            )
 
-            md = bytes([
-                int(f"0x{md[(i << 1): ((i+1) << 1)]}", base=16)
-                for i in range(len(md) >> 1)
-            ])
+            md = bytes(
+                [
+                    int(f"0x{md[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(md) >> 1)
+                ]
+            )
 
             digest = pb.photon_beetle_hash(msg)
 
-            assert (md == digest), f"[Photon-Beetle-Hash KAT {cnt}] expected {md}, found {digest} !"
+            assert (
+                md == digest
+            ), f"[Photon-Beetle-Hash KAT {cnt}] expected {md}, found {digest} !"
 
             fd.readline()
 
@@ -100,8 +103,12 @@ def test_photon_beetle_aead_32_kat():
             cipher, tag = pb.photon_beetle_32_encrypt(key, nonce, ad, pt)
             flag, text = pb.photon_beetle_32_decrypt(key, nonce, tag, ad, cipher)
 
-            assert (cipher + tag == ct), f"[Photon-Beetle-AEAD[32] KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
-            assert (pt == text and flag), f"[Photon-Beetle-AEAD[32] KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
+            assert (
+                cipher + tag == ct
+            ), f"[Photon-Beetle-AEAD[32] KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
+            assert (
+                pt == text and flag
+            ), f"[Photon-Beetle-AEAD[32] KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
 
             # don't need this line, so discard
             fd.readline()
@@ -162,13 +169,19 @@ def test_photon_beetle_aead_128_kat():
 
             cipher, tag = pb.photon_beetle_128_encrypt(key, nonce, ad, pt)
             flag, text = pb.photon_beetle_128_decrypt(key, nonce, tag, ad, cipher)
-            
-            assert (cipher + tag == ct), f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
-            assert (pt == text and flag), f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
+
+            assert (
+                cipher + tag == ct
+            ), f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
+            assert (
+                pt == text and flag
+            ), f"[Photon-Beetle-AEAD[128] KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
 
             # don't need this line, so discard
             fd.readline()
 
 
-if __name__ == '__main__':
-    print('Use `pytest` for driving Photon-Beetle tests against Known Answer Tests ( KAT ) !')
+if __name__ == "__main__":
+    print(
+        "Use `pytest` for driving Photon-Beetle tests against Known Answer Tests ( KAT ) !"
+    )


### PR DESCRIPTION
- [x] Compile-time compute serial matrix \$M^8\$, over \$GF(2^4)\$. 
> **Note** Previously I was maintaining a pre-computed table in source. Computing it during compile-time makes it more readable.
- [x] Rewrite tests to not use `numpy`, use only `ctypes` for foreign function interfacing
- [x] Update CI script to run tests inside Python virtual environment